### PR TITLE
Fix Python3 support

### DIFF
--- a/gjtk/validate.py
+++ b/gjtk/validate.py
@@ -286,7 +286,7 @@ def is_bbox(anything):
     """ Validate a GeoJSON Bounding Box. """
     if not isinstance(anything, list) or len(anything) < 1 or len(anything) % 2 != 0:
         return False
-    pivot = len(anything) / 2
+    pivot = int(len(anything) / 2)
     for i in range(pivot):
         if anything[i] > anything[i+pivot]:
             return False


### PR DESCRIPTION
```
______________________________________________________________________ ExampleTest.test_is_bbox _______________________________________________________________________

self = <gjtk.test.test_validate_examples.ExampleTest testMethod=test_is_bbox>

    def test_is_bbox(self):
        """should return true when provided an example Bbox"""
        test_data = random.choice([
            [-10.0, -10.0, 10.0, 10.0],
            [100.0, 0.0, 105.0, 1.0],
        ])
        self.assertTrue(
>           gjtk.validate.is_bbox(test_data),
            gjtk.test.error_message(test_data),
        )

gjtk/test/test_validate_examples.py:256: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
gjtk/validate.py:14: in wrapped_f
    return f(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

anything = [-10.0, -10.0, 10.0, 10.0]

    @boolean_fail
    def is_bbox(anything):
        """ Validate a GeoJSON Bounding Box. """
        if not isinstance(anything, list) or len(anything) < 1 or len(anything) % 2 != 0:
            return False
        pivot = len(anything) / 2
        print(pivot)
>       for i in range(pivot):
E       TypeError: 'float' object cannot be interpreted as an integer

gjtk/validate.py:292: TypeError
```